### PR TITLE
AuthCalloutService provide errors to nats 

### DIFF
--- a/examples/Example.AuthService/Program.cs
+++ b/examples/Example.AuthService/Program.cs
@@ -22,16 +22,16 @@ var jwt = new NatsJwt();
 
 await using var connection = new NatsConnection(new NatsOpts { AuthOpts = new NatsAuthOpts { CredsFile = creds } });
 
-ValueTask<string> Authorizer(NatsAuthorizationRequest r, CancellationToken cancellationToken)
+ValueTask<NatsAuthorizerResult> Authorizer(NatsAuthorizationRequest r, CancellationToken cancellationToken)
 {
     NatsUserClaims user = jwt.NewUserClaims(r.UserNKey);
 
     if (r.NatsConnectOptions.Name == "bad")
     {
-        return ValueTask.FromResult(string.Empty);
+        return ValueTask.FromResult(new NatsAuthorizerResult(string.Empty, 401, "user is not authorized"));
     }
 
-    return ValueTask.FromResult(jwt.EncodeUserClaims(user, akp));
+    return ValueTask.FromResult(new NatsAuthorizerResult(jwt.EncodeUserClaims(user, akp)));
 }
 
 ValueTask<string> ResponseSigner(NatsAuthorizationResponseClaims r, CancellationToken cancellationToken)

--- a/src/Synadia.AuthCallout/INatsAuthService.cs
+++ b/src/Synadia.AuthCallout/INatsAuthService.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) Synadia Communications, Inc. All rights reserved.
+// Copyright (c) Synadia Communications, Inc. All rights reserved.
 // Licensed under the Apache License, Version 2.0.
 
 using NATS.Client.Services;
@@ -26,6 +26,6 @@ public interface INatsAuthService : IAsyncDisposable
     /// </summary>
     /// <param name="msg">The incoming request message containing the data to process.</param>
     /// <param name="cancellationToken">A cancellation token to observe while waiting for the operation to complete.</param>
-    /// <returns>A task that represents the asynchronous operation, containing the processed response as a byte array.</returns>
-    ValueTask<byte[]> ProcessRequestAsync(NatsSvcMsg<byte[]> msg, CancellationToken cancellationToken = default);
+    /// <returns>A task that represents the asynchronous operation, containing the processed response as a NatsAuthServiceResponse with the JWT token and error code.</returns>
+    ValueTask<NatsAuthServiceResponse> ProcessRequestAsync(NatsSvcMsg<byte[]> msg, CancellationToken cancellationToken = default);
 }

--- a/src/Synadia.AuthCallout/NatsAuthService.cs
+++ b/src/Synadia.AuthCallout/NatsAuthService.cs
@@ -102,8 +102,10 @@ public class NatsAuthService : INatsAuthService
         {
             res.AuthorizationResponse.Error = authResult.ErrorMsg;
         }
-
-        res.AuthorizationResponse.Jwt = authResult.Token;
+        else
+        {
+            res.AuthorizationResponse.Jwt = authResult.Token;
+        }
 
         string tokenString = await _opts.ResponseSigner(res, cancellationToken);
         byte[] token = Encoding.ASCII.GetBytes(tokenString);

--- a/src/Synadia.AuthCallout/NatsAuthService.cs
+++ b/src/Synadia.AuthCallout/NatsAuthService.cs
@@ -48,8 +48,15 @@ public class NatsAuthService : INatsAuthService
             {
                 try
                 {
-                    byte[] token = await ProcessRequestAsync(msg, cancellationToken);
-                    await msg.ReplyAsync(token, cancellationToken: cancellationToken);
+                    NatsAuthServiceResponse res = await ProcessRequestAsync(msg, cancellationToken);
+                    if (res.ErrorCode == 0)
+                    {
+                        await msg.ReplyAsync(res.Token, cancellationToken: cancellationToken);
+                    }
+                    else
+                    {
+                        await msg.ReplyErrorAsync(res.ErrorCode, "Unauthorized", res.Token, cancellationToken: cancellationToken);
+                    }
                 }
                 catch (NatsAuthServiceAuthException e)
                 {
@@ -76,23 +83,27 @@ public class NatsAuthService : INatsAuthService
     }
 
     /// <inheritdoc />
-    public async ValueTask<byte[]> ProcessRequestAsync(NatsSvcMsg<byte[]> msg, CancellationToken cancellationToken = default)
+    public async ValueTask<NatsAuthServiceResponse> ProcessRequestAsync(
+        NatsSvcMsg<byte[]> msg,
+        CancellationToken cancellationToken = default)
     {
         var (isEncrypted, req) = DecodeJwt(msg);
-        var res = new NatsAuthorizationResponseClaims
-        {
-            Subject = req.UserNKey,
-            Audience = req.NatsServer.Id,
-        };
+        var res = new NatsAuthorizationResponseClaims { Subject = req.UserNKey, Audience = req.NatsServer.Id, };
 
-        string user = await _opts.Authorizer(req, cancellationToken);
+        NatsAuthorizerResult authResult = await _opts.Authorizer(req, cancellationToken);
 
-        if (user == string.Empty)
+        if (authResult is { Token: "", ErrorCode: 0 })
         {
-            throw new NatsAuthServiceAuthException("Error authorizing: authorizer didn't generate a JWT");
+            throw new NatsAuthServiceAuthException(
+                "Error authorizing: authorizer didn't generate a JWT and no error was provided");
         }
 
-        res.AuthorizationResponse.Jwt = user;
+        if (authResult.ErrorCode != 0 || authResult.ErrorMsg != string.Empty)
+        {
+            res.AuthorizationResponse.Error = authResult.ErrorMsg;
+        }
+
+        res.AuthorizationResponse.Jwt = authResult.Token;
 
         string tokenString = await _opts.ResponseSigner(res, cancellationToken);
         byte[] token = Encoding.ASCII.GetBytes(tokenString);
@@ -103,7 +114,7 @@ public class NatsAuthService : INatsAuthService
             token = seal;
         }
 
-        return token;
+        return new NatsAuthServiceResponse(token, authResult.ErrorCode);
     }
 
     /// <summary>
@@ -177,7 +188,8 @@ public class NatsAuthService : INatsAuthService
 
         if (arc.Issuer != arc.AuthorizationRequest.NatsServer.Id)
         {
-            throw new NatsAuthServiceException($"Bad request: issuers don't match: {arc.Issuer} != {arc.AuthorizationRequest.NatsServer.Id}");
+            throw new NatsAuthServiceException(
+                $"Bad request: issuers don't match: {arc.Issuer} != {arc.AuthorizationRequest.NatsServer.Id}");
         }
 
         if (arc.Audience != ExpectedAudience)

--- a/src/Synadia.AuthCallout/NatsAuthServiceOpts.cs
+++ b/src/Synadia.AuthCallout/NatsAuthServiceOpts.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) Synadia Communications, Inc. All rights reserved.
+// Copyright (c) Synadia Communications, Inc. All rights reserved.
 // Licensed under the Apache License, Version 2.0.
 
 using NATS.Jwt.Models;
@@ -17,7 +17,7 @@ public record NatsAuthServiceOpts
     /// <param name="authorizer">Authorizer callback.</param>
     /// <param name="responseSigner">Response signer callback.</param>
     public NatsAuthServiceOpts(
-        Func<NatsAuthorizationRequest, CancellationToken, ValueTask<string>> authorizer,
+        Func<NatsAuthorizationRequest, CancellationToken, ValueTask<NatsAuthorizerResult>> authorizer,
         Func<NatsAuthorizationResponseClaims, CancellationToken, ValueTask<string>> responseSigner)
     {
         Authorizer = authorizer;
@@ -32,9 +32,11 @@ public record NatsAuthServiceOpts
     public KeyPair? EncryptionKey { get; init; }
 
     /// <summary>
-    /// Gets a function that processes authorization request and issues user JWTs.
+    /// Gets a function that processes authorization request and returns authorization result.
+    /// The function takes a <see cref="NatsAuthorizationRequest"/> and a CancellationToken as input, and returns
+    /// a <see cref="NatsAuthorizerResult"/> which contains the user JWT and an optional error message.
     /// </summary>
-    public Func<NatsAuthorizationRequest, CancellationToken, ValueTask<string>> Authorizer { get; init; }
+    public Func<NatsAuthorizationRequest, CancellationToken, ValueTask<NatsAuthorizerResult>> Authorizer { get; init; }
 
     /// <summary>
     /// Gets a function that performs the signing of the <see cref="NatsAuthorizationResponseClaims"/>.

--- a/src/Synadia.AuthCallout/NatsAuthServiceResponse.cs
+++ b/src/Synadia.AuthCallout/NatsAuthServiceResponse.cs
@@ -1,0 +1,11 @@
+// Copyright (c) Synadia Communications, Inc. All rights reserved.
+// Licensed under the Apache License, Version 2.0.
+
+namespace Synadia.AuthCallout;
+
+/// <summary>
+/// Represents the response from a NATS authentication service operation.
+/// </summary>
+/// <param name="Token">The JWT token as a byte array that can be used for authentication.</param>
+/// <param name="ErrorCode">An error code indicating the result of the authentication operation. 0 indicates success.</param>
+public record NatsAuthServiceResponse(byte[] Token, int ErrorCode);

--- a/src/Synadia.AuthCallout/NatsAuthorizerResult.cs
+++ b/src/Synadia.AuthCallout/NatsAuthorizerResult.cs
@@ -1,0 +1,12 @@
+// Copyright (c) Synadia Communications, Inc. All rights reserved.
+// Licensed under the Apache License, Version 2.0.
+
+namespace Synadia.AuthCallout;
+
+/// <summary>
+/// Represents the result of a NATS authorization operation.
+/// </summary>
+/// <param name="Token">The user JWT Token string representing the authenticated user.</param>
+/// <param name="ErrorCode">Optional error code if authorization failed. 0 if successful.</param>
+/// <param name="ErrorMsg">Optional error message if authorization failed. Empty string if successful.</param>
+public record NatsAuthorizerResult(string Token, int ErrorCode = 0, string ErrorMsg = "");

--- a/tests/Synadia.AuthCallout.Tests/AuthServiceTest.cs
+++ b/tests/Synadia.AuthCallout.Tests/AuthServiceTest.cs
@@ -98,10 +98,10 @@ public class AuthServiceTest(ITestOutputHelper output)
 
                 if (r.NatsConnectOptions.Name == "bad")
                 {
-                    return ValueTask.FromResult(string.Empty);
+                    return ValueTask.FromResult(new NatsAuthorizerResult(string.Empty, 401, "Unauthorized"));
                 }
 
-                return ValueTask.FromResult(jwt.EncodeUserClaims(user, akp));
+                return ValueTask.FromResult(new NatsAuthorizerResult(jwt.EncodeUserClaims(user, akp)));
             },
             responseSigner: (r, ct) => ValueTask.FromResult(jwt.EncodeAuthorizationResponseClaims(r, akp)))
         {
@@ -172,10 +172,10 @@ public class AuthServiceTest(ITestOutputHelper output)
 
                 if (r.NatsConnectOptions.Name == "bad")
                 {
-                    return ValueTask.FromResult(string.Empty);
+                    return ValueTask.FromResult(new NatsAuthorizerResult(string.Empty, 401, "Unauthorized"));
                 }
 
-                return ValueTask.FromResult(jwt.EncodeUserClaims(user, akp));
+                return ValueTask.FromResult(new NatsAuthorizerResult(jwt.EncodeUserClaims(user, akp)));
             },
             responseSigner: (r, ct) => ValueTask.FromResult(jwt.EncodeAuthorizationResponseClaims(r, akp)))
         {

--- a/tests/compat/Testing.cs
+++ b/tests/compat/Testing.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) Synadia Communications, Inc. All rights reserved.
+// Copyright (c) Synadia Communications, Inc. All rights reserved.
 // Licensed under the Apache License, Version 2.0.
 
 #pragma warning disable
@@ -251,7 +251,7 @@ public class Testing
 
     public async Task TestEncryptionMismatch(TestContext t)
     {
-        ValueTask<string> Authorizer(NatsAuthorizationRequest r, CancellationToken cancellationToken)
+        ValueTask<NatsAuthorizerResult> Authorizer(NatsAuthorizationRequest r, CancellationToken cancellationToken)
         {
             throw new Exception("checks at the handler should stop the request before it gets here");
         }
@@ -275,7 +275,7 @@ public class Testing
 
     public async Task TestSetupOK(TestContext t)
     {
-        async ValueTask<string> Authorizer(NatsAuthorizationRequest r, CancellationToken cancellationToken)
+        async ValueTask<NatsAuthorizerResult> Authorizer(NatsAuthorizationRequest r, CancellationToken cancellationToken)
         {
             Log(2, $"Auth user: {r.NatsConnectOptions.Username}");
             NatsUserClaims user = t.jwt.NewUserClaims(r.UserNKey);
@@ -284,7 +284,7 @@ public class Testing
             user.User.Sub.Allow = ["_INBOX.>"];
             user.Expires = DateTimeOffset.Now + TimeSpan.FromSeconds(90);
 
-            return t.Encoder.Encode(user);
+            return new NatsAuthorizerResult(t.Encoder.Encode(user));
         }
 
         async ValueTask<string> ResponseSigner(NatsAuthorizationResponseClaims r, CancellationToken cancellationToken)
@@ -303,7 +303,7 @@ public class Testing
 
     public async Task TestAbortRequest(TestContext t)
     {
-        async ValueTask<string> Authorizer(NatsAuthorizationRequest r, CancellationToken cancellationToken)
+        async ValueTask<NatsAuthorizerResult> Authorizer(NatsAuthorizationRequest r, CancellationToken cancellationToken)
         {
             Log(2, $"Auth user: {r.NatsConnectOptions.Username}");
 
@@ -319,7 +319,7 @@ public class Testing
 
             if (r.NatsConnectOptions.Username == "blank")
             {
-                return "";
+                return new NatsAuthorizerResult(string.Empty, 401, "Unauthorized");
             }
 
             NatsUserClaims user = t.jwt.NewUserClaims(r.UserNKey);
@@ -328,7 +328,7 @@ public class Testing
             user.User.Sub.Allow = ["_INBOX.>"];
             user.Expires = DateTimeOffset.Now + TimeSpan.FromSeconds(90);
 
-            return t.Encoder.Encode(user);
+            return new NatsAuthorizerResult(t.Encoder.Encode(user));
         }
 
         async ValueTask<string> ResponseSigner(NatsAuthorizationResponseClaims r, CancellationToken cancellationToken)


### PR DESCRIPTION
This proposed change adds
- `NatsAuthorizerResult`
- `NatsAuthServiceResponse`

The `Authorizer` callback can now fill in an error code and error message to cause `AuthCalloutService` to reply with a reason to nats. If it isn't filled in and the JWT is string.Empty then the current behavior will occur and no reason will be supplied.

Closes #9 