### PR TITLE
Update to NATS.Jwt v1.0.0-preview.16 static API

### DIFF
--- a/examples/Example.AuthService/Program.cs
+++ b/examples/Example.AuthService/Program.cs
@@ -18,25 +18,24 @@ string issuer = "/tmp/DA/A.nk";
 
 KeyPair ckp = KeyPair.FromSeed(File.ReadAllText(calloutIssuer));
 KeyPair akp = KeyPair.FromSeed(File.ReadAllText(issuer));
-var jwt = new NatsJwt();
 
 await using var connection = new NatsConnection(new NatsOpts { AuthOpts = new NatsAuthOpts { CredsFile = creds } });
 
 ValueTask<NatsAuthorizerResult> Authorizer(NatsAuthorizationRequest r, CancellationToken cancellationToken)
 {
-    NatsUserClaims user = jwt.NewUserClaims(r.UserNKey);
+    NatsUserClaims user = NatsJwt.NewUserClaims(r.UserNKey);
 
     if (r.NatsConnectOptions.Name == "bad")
     {
         return ValueTask.FromResult(new NatsAuthorizerResult(string.Empty, 401, "user is not authorized"));
     }
 
-    return ValueTask.FromResult(new NatsAuthorizerResult(jwt.EncodeUserClaims(user, akp)));
+    return ValueTask.FromResult(new NatsAuthorizerResult(NatsJwt.EncodeUserClaims(user, akp)));
 }
 
 ValueTask<string> ResponseSigner(NatsAuthorizationResponseClaims r, CancellationToken cancellationToken)
 {
-    return ValueTask.FromResult(jwt.EncodeAuthorizationResponseClaims(r, ckp));
+    return ValueTask.FromResult(NatsJwt.EncodeAuthorizationResponseClaims(r, ckp));
 }
 
 var opts = new NatsAuthServiceOpts(Authorizer, ResponseSigner)

--- a/src/Synadia.AuthCallout/NatsAuthService.cs
+++ b/src/Synadia.AuthCallout/NatsAuthService.cs
@@ -23,7 +23,6 @@ public class NatsAuthService : INatsAuthService
     private const string SysRequestUserAuthSubj = "$SYS.REQ.USER.AUTH";
     private readonly INatsSvcContext _svc;
     private readonly NatsAuthServiceOpts _opts;
-    private readonly NatsJwt _natsJwt = new();
     private readonly ILogger<NatsAuthService> _logger;
     private readonly CancellationTokenSource _cts = new();
     private INatsSvcServer? _server;
@@ -197,7 +196,7 @@ public class NatsAuthService : INatsAuthService
             jwt = Encoding.ASCII.GetString(open);
         }
 
-        NatsAuthorizationRequestClaims arc = _natsJwt.DecodeClaims<NatsAuthorizationRequestClaims>(jwt);
+        NatsAuthorizationRequestClaims arc = NatsJwt.DecodeClaims<NatsAuthorizationRequestClaims>(jwt);
 
         if (!arc.Issuer.StartsWith("N"))
         {

--- a/src/Synadia.AuthCallout/PACKAGE.md
+++ b/src/Synadia.AuthCallout/PACKAGE.md
@@ -8,19 +8,18 @@ string issuer = "/path/to/seed/file/A.nk";
 
 KeyPair ckp = KeyPair.FromSeed(File.ReadAllText(calloutIssuer));
 KeyPair akp = KeyPair.FromSeed(File.ReadAllText(issuer));
-var jwt = new NatsJwt();
 
 await using var connection = new NatsConnection(new NatsOpts { AuthOpts = new NatsAuthOpts { CredsFile = "/path/to/service.creds" } });
 
 async ValueTask<string> Authorizer(NatsAuthorizationRequest r)
 {
-    NatsUserClaims user = jwt.NewUserClaims(r.UserNKey);
-    return jwt.EncodeUserClaims(user, akp);
+    NatsUserClaims user = NatsJwt.NewUserClaims(r.UserNKey);
+    return NatsJwt.EncodeUserClaims(user, akp);
 }
 
 async ValueTask<string> ResponseSigner(NatsAuthorizationResponseClaims r)
 {
-    return jwt.EncodeAuthorizationResponseClaims(r, ckp);
+    return NatsJwt.EncodeAuthorizationResponseClaims(r, ckp);
 }
 
 var opts = new NatsAuthServiceOpts(Authorizer, ResponseSigner)

--- a/src/Synadia.AuthCallout/Synadia.AuthCallout.csproj
+++ b/src/Synadia.AuthCallout/Synadia.AuthCallout.csproj
@@ -12,7 +12,7 @@
 
   <ItemGroup>
     <PackageReference Include="NATS.Client.Services" Version="2.5.12"/>
-    <PackageReference Include="NATS.Jwt" Version="1.0.0-preview.12"/>
+    <PackageReference Include="NATS.Jwt" Version="1.0.0-preview.16"/>
   </ItemGroup>
 
 </Project>

--- a/src/Synadia.AuthCallout/version.txt
+++ b/src/Synadia.AuthCallout/version.txt
@@ -1,1 +1,1 @@
-1.0.0-preview.4
+1.0.0-preview.5

--- a/tests/Synadia.AuthCallout.Tests/AuthServiceTest.cs
+++ b/tests/Synadia.AuthCallout.Tests/AuthServiceTest.cs
@@ -15,24 +15,23 @@ public class AuthServiceTest(ITestOutputHelper output)
     [Fact]
     public async Task Connect_with_jwt()
     {
-        var jwt = new NatsJwt();
         var okp = KeyPair.CreatePair(PrefixByte.Operator);
         var opk = okp.GetPublicKey();
-        var oc = jwt.NewOperatorClaims(opk);
+        var oc = NatsJwt.NewOperatorClaims(opk);
         oc.Name = "Example Operator";
         var oskp = KeyPair.CreatePair(PrefixByte.Operator);
         var ospk = oskp.GetPublicKey();
         oc.Operator.SigningKeys = [ospk];
-        var operatorJwt = jwt.EncodeOperatorClaims(oc, okp);
+        var operatorJwt = NatsJwt.EncodeOperatorClaims(oc, okp);
 
         var akp = KeyPair.CreatePair(PrefixByte.Account);
         var apk = akp.GetPublicKey();
-        var ac = jwt.NewAccountClaims(apk);
+        var ac = NatsJwt.NewAccountClaims(apk);
         ac.Name = "Example Account";
         var askp = KeyPair.CreatePair(PrefixByte.Account);
         var aspk = askp.GetPublicKey();
         ac.Account.SigningKeys = [aspk];
-        var accountJwt = jwt.EncodeAccountClaims(ac, oskp);
+        var accountJwt = NatsJwt.EncodeAccountClaims(ac, oskp);
 
         string conf = $$"""
                         operator: {{operatorJwt}}
@@ -47,9 +46,9 @@ public class AuthServiceTest(ITestOutputHelper output)
 
         var ukp = KeyPair.CreatePair(PrefixByte.User);
         var upk = ukp.GetPublicKey();
-        var uc = jwt.NewUserClaims(upk);
+        var uc = NatsJwt.NewUserClaims(upk);
         uc.User.IssuerAccount = apk;
-        var userJwt = jwt.EncodeUserClaims(uc, askp);
+        var userJwt = NatsJwt.EncodeUserClaims(uc, askp);
         var userSeed = ukp.GetSeed();
 
         var authOpts = new NatsAuthOpts { Jwt = userJwt, Seed = userSeed };
@@ -61,8 +60,6 @@ public class AuthServiceTest(ITestOutputHelper output)
     [Fact]
     public async Task Connect_with_callout()
     {
-        var jwt = new NatsJwt();
-
         var akp = KeyPair.CreatePair(PrefixByte.Account);
         var apk = akp.GetPublicKey();
 
@@ -90,7 +87,7 @@ public class AuthServiceTest(ITestOutputHelper output)
         var opts = new NatsAuthServiceOpts(
             authorizer: (r, ct) =>
             {
-                NatsUserClaims user = jwt.NewUserClaims(r.UserNKey);
+                NatsUserClaims user = NatsJwt.NewUserClaims(r.UserNKey);
                 user.Audience = "AUTH";
                 user.Name = Convert.ToBase64String(Encoding.UTF8.GetBytes("User1"));
                 user.User.Pub.Allow = [">"];
@@ -101,9 +98,9 @@ public class AuthServiceTest(ITestOutputHelper output)
                     return ValueTask.FromResult(new NatsAuthorizerResult(string.Empty, 401, "Unauthorized"));
                 }
 
-                return ValueTask.FromResult(new NatsAuthorizerResult(jwt.EncodeUserClaims(user, akp)));
+                return ValueTask.FromResult(new NatsAuthorizerResult(NatsJwt.EncodeUserClaims(user, akp)));
             },
-            responseSigner: (r, ct) => ValueTask.FromResult(jwt.EncodeAuthorizationResponseClaims(r, akp)))
+            responseSigner: (r, ct) => ValueTask.FromResult(NatsJwt.EncodeAuthorizationResponseClaims(r, akp)))
         {
             ErrorHandler = (e, ct) =>
             {
@@ -132,8 +129,6 @@ public class AuthServiceTest(ITestOutputHelper output)
     [Fact]
     public async Task Connect_with_callout_with_xkey()
     {
-        var jwt = new NatsJwt();
-
         var xkp = KeyPair.CreatePair(PrefixByte.Curve);
 
         var akp = KeyPair.CreatePair(PrefixByte.Account);
@@ -164,7 +159,7 @@ public class AuthServiceTest(ITestOutputHelper output)
         var opts = new NatsAuthServiceOpts(
             authorizer: (r, ct) =>
             {
-                NatsUserClaims user = jwt.NewUserClaims(r.UserNKey);
+                NatsUserClaims user = NatsJwt.NewUserClaims(r.UserNKey);
                 user.Audience = "AUTH";
                 user.Name = Convert.ToBase64String(Encoding.UTF8.GetBytes("User1"));
                 user.User.Pub.Allow = [">"];
@@ -175,9 +170,9 @@ public class AuthServiceTest(ITestOutputHelper output)
                     return ValueTask.FromResult(new NatsAuthorizerResult(string.Empty, 401, "Unauthorized"));
                 }
 
-                return ValueTask.FromResult(new NatsAuthorizerResult(jwt.EncodeUserClaims(user, akp)));
+                return ValueTask.FromResult(new NatsAuthorizerResult(NatsJwt.EncodeUserClaims(user, akp)));
             },
-            responseSigner: (r, ct) => ValueTask.FromResult(jwt.EncodeAuthorizationResponseClaims(r, akp)))
+            responseSigner: (r, ct) => ValueTask.FromResult(NatsJwt.EncodeAuthorizationResponseClaims(r, akp)))
         {
             EncryptionKey = xkp,
             ErrorHandler = (e, ct) =>

--- a/tests/compat/TestContext.cs
+++ b/tests/compat/TestContext.cs
@@ -20,7 +20,6 @@ public record TestContext
     public NatsConnection connection { get; init; }
     public string name { get; init; }
     public string suitName { get; init; }
-    public NatsJwt jwt { get; init; }
     public string env { get; init; }
 
     public IClaimsEncoder Encoder
@@ -142,12 +141,12 @@ public class BasicClaimsEncoder : IClaimsEncoder
 
     public string Encode(NatsUserClaims claims)
     {
-        return _t.jwt.EncodeUserClaims(claims, _t.cv.AccountKeys["A"]);
+        return NatsJwt.EncodeUserClaims(claims, _t.cv.AccountKeys["A"]);
     }
 
     public string Encode(NatsAuthorizationResponseClaims claims)
     {
-        return _t.jwt.EncodeAuthorizationResponseClaims(claims, _t.cv.AccountKeys["A"]);
+        return NatsJwt.EncodeAuthorizationResponseClaims(claims, _t.cv.AccountKeys["A"]);
     }
 }
 
@@ -166,7 +165,7 @@ public class DelegatedClaimsEncoder : IClaimsEncoder
         var op = store.LoadOperators().First(o => o.Name == "O");
         var a = op.Accounts.First(a => a.Name == "A");
         claims.User.IssuerAccount = a.Subject.GetPublicKey();
-        return _t.jwt.EncodeUserClaims(claims, a.SigningKeys[0]);
+        return NatsJwt.EncodeUserClaims(claims, a.SigningKeys[0]);
     }
 
     public string Encode(NatsAuthorizationResponseClaims claims)
@@ -175,6 +174,6 @@ public class DelegatedClaimsEncoder : IClaimsEncoder
         var op = store.LoadOperators().First(o => o.Name == "O");
         var c = op.Accounts.First(a => a.Name == "C");
         claims.AuthorizationResponse.IssuerAccount = c.Subject.GetPublicKey();
-        return _t.jwt.EncodeAuthorizationResponseClaims(claims, c.SigningKeys[0]);
+        return NatsJwt.EncodeAuthorizationResponseClaims(claims, c.SigningKeys[0]);
     }
 }

--- a/tests/compat/Testing.cs
+++ b/tests/compat/Testing.cs
@@ -231,7 +231,6 @@ public class Testing
                 tcs = tcs,
                 nt = nt,
                 connection = connection,
-                jwt = new NatsJwt(),
             };
 
             MethodInfo? methodInfo = GetType().GetMethod(name);
@@ -278,7 +277,7 @@ public class Testing
         async ValueTask<NatsAuthorizerResult> Authorizer(NatsAuthorizationRequest r, CancellationToken cancellationToken)
         {
             Log(2, $"Auth user: {r.NatsConnectOptions.Username}");
-            NatsUserClaims user = t.jwt.NewUserClaims(r.UserNKey);
+            NatsUserClaims user = NatsJwt.NewUserClaims(r.UserNKey);
             user.Audience = t.cv.Audience;
             user.User.Pub.Allow = [t.cv.UserInfoSubj];
             user.User.Sub.Allow = ["_INBOX.>"];
@@ -322,7 +321,7 @@ public class Testing
                 return new NatsAuthorizerResult(string.Empty, 401, "Unauthorized");
             }
 
-            NatsUserClaims user = t.jwt.NewUserClaims(r.UserNKey);
+            NatsUserClaims user = NatsJwt.NewUserClaims(r.UserNKey);
             user.Audience = t.cv.Audience;
             user.User.Pub.Allow = [t.cv.UserInfoSubj];
             user.User.Sub.Allow = ["_INBOX.>"];


### PR DESCRIPTION
## Summary
Updates Synadia.AuthCallout to be compatible with NATS.Jwt v1.0.0-preview.13+ which changed NatsJwt from an instance-based class to a static class.

## Problem
Synadia.AuthCallout v1.0.0-preview.4 is incompatible with NATS.Jwt v1.0.0-preview.16+ which changed the NatsJwt API. Consuming applications encounter:
```
System.MissingMethodException: Method not found: 'Void NATS.Jwt.NatsJwt..ctor()'
```

## Root Cause
NATS.Jwt preview.13+ changed the API:
- **Old (preview.12)**: `var jwt = new NatsJwt(); jwt.EncodeUserClaims(...)`
- **New (preview.13+)**: `NatsJwt.EncodeUserClaims(...)` (static methods, no constructor)

## Changes
- Removed all `NatsJwt` instance fields and instantiations
- Updated all method calls to use static API:
  - `jwt.EncodeUserClaims(...)` → `NatsJwt.EncodeUserClaims(...)`
  - `jwt.EncodeAuthorizationResponseClaims(...)` → `NatsJwt.EncodeAuthorizationResponseClaims(...)`
  - `jwt.NewUserClaims(...)` → `NatsJwt.NewUserClaims(...)`
  - `jwt.DecodeClaims<>()` → `NatsJwt.DecodeClaims<>()`
- Updated NATS.Jwt package reference: `1.0.0-preview.12` → `1.0.0-preview.16`
- Bumped library version: `1.0.0-preview.4` → `1.0.0-preview.5`
- Updated documentation (PACKAGE.md) with new static API usage

## Files Modified
- `src/Synadia.AuthCallout/NatsAuthService.cs`
- `src/Synadia.AuthCallout/Synadia.AuthCallout.csproj`
- `src/Synadia.AuthCallout/version.txt`
- `src/Synadia.AuthCallout/PACKAGE.md`
- `examples/Example.AuthService/Program.cs`
- `tests/Synadia.AuthCallout.Tests/AuthServiceTest.cs`
- `tests/compat/TestContext.cs`
- `tests/compat/Testing.cs`

## Testing
- ✅ Build successful (no warnings or errors)
- ✅ Code formatting passes (`dotnet format --verify-no-changes`)
- All test files updated to use static API

## Impact
This is a **non-breaking change** for consumers already using preview.12, but enables compatibility with newer NATS.Jwt versions (preview.13+).