### PR TITLE
Add Claude Code review bot workflow

### DIFF
--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -1,0 +1,30 @@
+name: Claude Code
+
+permissions:
+  contents: read
+  actions: read
+
+on:
+  issue_comment:
+    types: [created]
+  pull_request_review_comment:
+    types: [created]
+  pull_request_target:
+    types: [opened, reopened, review_requested]
+
+jobs:
+  claude:
+    uses: synadia-io/ai-workflows/.github/workflows/claude.yml@v2
+    with:
+      gh_app_id: ${{ vars.CLAUDE_GH_APP_ID }}
+      checkout_mode: base
+      review_focus: |
+        Additionally focus on:
+        - Async/await correctness: cancellation token propagation, ValueTask usage, async disposal
+        - Memory and performance: buffer pooling, allocation pressure, span usage
+        - NATS protocol correctness: message serialization, header handling, JetStream ack semantics
+        - API surface compatibility: public API changes, backward compatibility, nullable annotations
+        - Thread safety in connection handling and subscription management
+    secrets:
+      claude_oauth_token: ${{ secrets.CLAUDE_OAUTH_TOKEN }}
+      gh_app_private_key: ${{ secrets.CLAUDE_GH_APP_PRIVATE_KEY }}


### PR DESCRIPTION
Add the Claude Code review bot workflow, reusing the shared synadia-io/ai-workflows reusable workflow. Matches the existing orbit.net setup with .NET-focused review guidance.